### PR TITLE
Add support for HW UART

### DIFF
--- a/cpld/rtl/mem.sv
+++ b/cpld/rtl/mem.sv
@@ -83,6 +83,11 @@ module mem(
     input ay_dout_active,
     input ports_dout_active,
     input [7:0] ports_dout
+`ifdef REV_E
+    ,
+    input uart_dout_active,
+    input [7:0] uart_dout
+`endif
 );
 
 wire romreq = bus.mreq && !bus.rfsh && bus.a[15:14] == 2'b00 &&
@@ -213,6 +218,9 @@ assign xd[7:0] =
     div_dout_active                ? div_dout :
     up_dout_active                 ? up_dout :
     ports_dout_active              ? ports_dout :
+`ifdef REV_E
+    uart_dout_active               ? uart_dout :
+`endif
     xd_precharge                   ? 8'hFF :
                                      {8{1'bz}} ;
 

--- a/cpld/rtl/top.sv
+++ b/cpld/rtl/top.sv
@@ -80,6 +80,13 @@ module zx_ula (
     output plus3_dwr,
     output plus3_mtr
 
+`ifdef REV_E
+    ,
+    input uart_rx,
+    output uart_tx,
+    output uart_rts
+`endif
+
 `ifndef REV_C
     ,
     input ps2_clk,
@@ -574,6 +581,24 @@ divmmc divmmc0(
     .ext_wait_cycle2(div_ext_wait_cycle2)
 );
 
+`ifdef REV_E
+wire uart_dout_active;
+wire [7:0] uart_dout;
+
+/* UART */
+uart uart0(
+    .rst_n(n_rstcpu_in),
+    .clk28(clk28),
+    .bus(bus),
+    .en(1'b1),
+    .d_out(uart_dout),
+    .d_out_active(uart_dout_active),
+
+    .uart_rx(uart_rx),
+    .uart_tx(uart_tx),
+    .uart_rts(uart_rts)
+);
+`endif
 
 /* ULAPLUS */
 wire up_dout_active;
@@ -651,6 +676,11 @@ mem mem0(
     .ay_dout_active(ay_dout_active),
     .ports_dout_active(ports_dout_active),
     .ports_dout(ports_dout)
+`ifdef REV_E
+    ,
+    .uart_dout(uart_dout),
+    .uart_dout_active(uart_dout_active)
+`endif
 );
 
 

--- a/cpld/rtl/top.sv
+++ b/cpld/rtl/top.sv
@@ -108,6 +108,7 @@ wire up_active;
 wire [2:0] ram_page128;
 wire ay_ext_wait_cycle2;
 wire div_ext_wait_cycle2;
+wire uart_ext_wait_cycle2;
 wire mem_wait;
 wire sd_indication;
 wire bright_boost;
@@ -361,7 +362,7 @@ cpu cpu0(
     .turbo(turbo),
     .fastforward(fastforward),
     .hold(mem_wait),
-    .ext_wait_cycle2(ay_ext_wait_cycle2 | div_ext_wait_cycle2),
+    .ext_wait_cycle2(ay_ext_wait_cycle2 | div_ext_wait_cycle2 | uart_ext_wait_cycle2),
 
     .n_rstcpu_out(n_rstcpu_out),
     .clkcpu(clkcpu),
@@ -596,7 +597,8 @@ uart uart0(
 
     .uart_rx(uart_rx),
     .uart_tx(uart_tx),
-    .uart_rts(uart_rts)
+    .uart_rts(uart_rts),
+    .ext_wait_cycle2(uart_ext_wait_cycle2)
 );
 `endif
 

--- a/cpld/rtl/uart.sv
+++ b/cpld/rtl/uart.sv
@@ -1,0 +1,245 @@
+import common::*;
+
+module uart(
+    input rst_n,
+    input clk28,
+    input en,
+
+    cpu_bus bus,
+    output [7:0] d_out,
+    output d_out_active,
+
+    input uart_rx,
+    output reg uart_tx,
+    output reg uart_rts
+);
+
+localparam CLK_HZ = 28000000;
+localparam BAUD_RATE = 115200;
+localparam PERIOD_1_4 = (CLK_HZ / (BAUD_RATE * 8));
+
+localparam
+    IDLE  = 3'd0,
+    START = 3'd1,
+    DATA  = 3'd2,
+    STOP  = 3'd3,
+    WAIT  = 3'd4;
+
+reg [5:0] clk_cnt = 6'b0;
+/* bit_clk[0] is 115200 * 4, bit_clk[2] is 115200 */
+reg [2:0] bit_clk = 3'b0;
+
+reg tx_start = 1'b0;
+reg tx_busy = 1'b0;
+reg rx_ready = 1'b0;
+reg rx_data_read = 1'b0;
+reg [1:0] tx_state = IDLE;
+reg [2:0] rx_state = IDLE;
+
+reg [7:0] tx_data = 8'hFF;
+reg [7:0] rx_data = 8'h00;
+
+wire uart_tx_rd = en && bus.iorq && bus.rd && bus.a == 16'h133B;
+wire uart_tx_wr = en && bus.iorq && bus.wr && bus.a == 16'h133B;
+wire uart_rx_rd = en && bus.iorq && bus.rd && bus.a == 16'h143B;
+
+always @(posedge clk28 or negedge rst_n) begin
+    if (!rst_n) begin
+        rx_data_read <= 0;
+    end
+    else begin
+        if (rx_data_read && !rx_ready) begin
+            rx_data_read <= 0;
+        end
+        if (uart_tx_rd) begin
+            d_out <= {6'h00, tx_busy | tx_start, rx_ready & !rx_data_read};
+        end
+        else if (uart_rx_rd) begin
+            d_out <= rx_data;
+            if (rx_ready) begin
+                rx_data_read <= 1'b1;
+            end;
+        end
+        d_out_active <= uart_tx_rd | uart_rx_rd;
+    end
+end
+
+always @(posedge clk28 or negedge rst_n) begin
+    if (!rst_n) begin
+        clk_cnt <= 6'h0;
+        bit_clk <= 3'h0;
+    end
+    else begin
+        clk_cnt <= clk_cnt + 1'b1;
+        if (clk_cnt == PERIOD_1_4) begin
+            clk_cnt <= 6'b0;
+            bit_clk <= bit_clk + 1'b1;
+        end
+    end
+end
+
+always @(posedge clk28 or negedge rst_n) begin
+    if (!rst_n) begin
+        tx_start <= 0;
+    end
+    else begin
+        if (uart_tx_wr && !tx_start && !tx_busy) begin
+            tx_data <= bus.d;
+            tx_start <= 1'b1;
+        end
+        else if (tx_start && tx_busy) begin
+            tx_start <= 0;
+        end
+    end
+end
+
+reg [2:0] tx_bit_cnt = 3'b0;
+reg [7:0] tx_work_data = 8'hFF;
+
+
+/* TX state machine. Works on bit_clk (baud rate) */
+always @(negedge bit_clk[2] or negedge rst_n) begin
+    if (!rst_n) begin
+        tx_busy <= 0;
+        tx_state <= IDLE;
+        tx_bit_cnt <= 0;
+        uart_tx <= 1'b1;
+    end
+    else begin
+        case (tx_state)
+            IDLE:
+                begin
+                    if (tx_start) begin
+                        tx_busy <= 1'b1;
+                        tx_state <= START;
+                    end
+                end
+            START:
+                begin
+                    tx_work_data <= tx_data;
+                    uart_tx <= 1'b0;
+                    tx_bit_cnt <= 3'd7;
+                    tx_state <= DATA;
+                end
+            DATA:
+                begin
+                    uart_tx <= tx_work_data[0];
+                    tx_work_data <= {1'b0, tx_work_data[7:1]};
+                    tx_bit_cnt <= tx_bit_cnt - 3'd1;
+                    if (tx_bit_cnt == 3'd0) begin
+                        tx_state <= STOP;
+                    end
+                end
+            STOP:
+                begin
+                    uart_tx <= 1'b1;
+                    tx_busy <= 1'b0;
+                    tx_state <= IDLE;
+                end
+            default:
+                begin
+                    tx_state <= IDLE;
+                end
+        endcase
+    end
+end
+
+reg [1:0] bit_clk4x_samples = 2'b00;
+wire sample_tick = { bit_clk4x_samples == 2'b10 };
+
+reg [1:0] rx_clk_cnt;
+wire rx_bit_middle = { rx_clk_cnt == 2'd2 };
+
+reg [2:0] rx_bit_cnt;
+
+/* RX state machine. Works on bit_clk * 4 (baud_rate * 4) */
+always @(posedge clk28 or negedge rst_n) begin
+    if (!rst_n) begin
+        // Raise RTS to indicate that we are not ready to receive.
+        uart_rts <= 1'b1;
+        rx_state <= IDLE;
+        rx_ready <= 0;
+        rx_data <= 8'hff;
+    end
+    else begin
+        bit_clk4x_samples <= { bit_clk4x_samples[0], bit_clk[0] };
+        case (rx_state)
+            IDLE:
+                begin
+                    rx_ready <= 0;
+                    if (sample_tick) begin
+                        uart_rts <= 0; // Lower RTS to signal that we are ready to receive data
+                        if (!uart_rx) begin
+                            rx_state <= START;
+                            rx_clk_cnt <= 2'd1; // We may have lost up to 1 cycle waiting for negedge
+                        end
+                    end
+                end
+            START:
+                begin
+                    if (sample_tick) begin
+                        rx_clk_cnt <= rx_clk_cnt + 2'b1;
+                        if (rx_bit_middle) begin // Middle of the bit
+                            if (uart_rx) begin
+                                // Start must be 0, go back to IDLE
+                                rx_state <= IDLE;
+                            end
+                        end
+                        // Start bit confirmed, wait for 2 more cycles and
+                        // switch to DATA state
+                        else if (rx_clk_cnt == 2'd0) begin
+                            rx_data <= 8'h00;
+                            rx_state <= DATA;
+                            rx_bit_cnt <= 3'd7;
+                        end
+                    end
+                end
+            DATA:
+                begin
+                    if (sample_tick) begin
+                        rx_clk_cnt <= rx_clk_cnt + 2'b1;
+                        if (rx_bit_middle) begin // Middle of the bit
+                            // Sample data bit
+                            rx_data <= { uart_rx, rx_data[7:1] };
+                        end
+                        else if (rx_clk_cnt == 2'd0) begin
+                            rx_bit_cnt <= rx_bit_cnt - 3'd1;
+                            if (rx_bit_cnt == 3'd0) begin
+                                rx_state <= STOP;
+                            end
+                        end
+                    end
+                end
+            STOP:
+                begin
+                    if (sample_tick) begin
+                        rx_clk_cnt <= rx_clk_cnt + 2'b1;
+                        if (rx_bit_middle) begin // Middle of the bit
+                            if (!uart_rx) begin
+                                // Stop bit must be 1. Go back to IDLE
+                                rx_state <= IDLE;
+                            end
+                            else begin
+                                // Data received successfully
+                                rx_ready <= 1'b1;
+                                uart_rts <= 1'b1; // Raise RTS to signal that we are not ready to receive more data
+                                rx_state <= WAIT;
+                            end
+                        end
+                    end
+                end
+            WAIT:
+                begin
+                    if (rx_data_read) begin
+                        rx_state <= IDLE;
+                    end
+                end
+            default:
+                begin
+                    rx_state <= IDLE;
+                end
+        endcase
+    end
+end
+
+endmodule

--- a/cpld/rtl/uart.sv
+++ b/cpld/rtl/uart.sv
@@ -11,7 +11,8 @@ module uart(
 
     input uart_rx,
     output reg uart_tx,
-    output reg uart_rts
+    output reg uart_rts,
+    output ext_wait_cycle2
 );
 
 localparam CLK_HZ = 28000000;
@@ -42,6 +43,8 @@ reg [7:0] rx_data = 8'h00;
 wire uart_tx_rd = en && bus.iorq && bus.rd && bus.a == 16'h133B;
 wire uart_tx_wr = en && bus.iorq && bus.wr && bus.a == 16'h133B;
 wire uart_rx_rd = en && bus.iorq && bus.rd && bus.a == 16'h143B;
+
+assign ext_wait_cycle2 = uart_tx_rd || uart_tx_wr || uart_rx_rd;
 
 always @(posedge clk28 or negedge rst_n) begin
     if (!rst_n) begin

--- a/cpld/syn/rev_E.qsf
+++ b/cpld/syn/rev_E.qsf
@@ -102,6 +102,7 @@ set_location_assignment PIN_14 -to kd[3]
 set_location_assignment PIN_15 -to kd[2]
 set_location_assignment PIN_16 -to kd[1]
 set_location_assignment PIN_18 -to kd[0]
+set_location_assignment PIN_21 -to uart_rts
 set_location_assignment PIN_22 -to bus0
 set_location_assignment PIN_23 -to bus1
 set_location_assignment PIN_24 -to n_romcs
@@ -157,6 +158,8 @@ set_location_assignment PIN_87 -to ay_bdir
 set_location_assignment PIN_88 -to snd_r
 set_location_assignment PIN_89 -to ay_clk
 set_location_assignment PIN_91 -to clk28
+set_location_assignment PIN_93 -to uart_rx
+set_location_assignment PIN_97 -to uart_tx
 set_location_assignment PIN_98 -to shift_clk
 set_location_assignment PIN_101 -to vd[3]
 set_location_assignment PIN_102 -to vd[4]
@@ -243,6 +246,7 @@ set_global_assignment -name SYSTEMVERILOG_FILE ../rtl/cpu.sv
 set_global_assignment -name SYSTEMVERILOG_FILE ../rtl/mem.sv
 set_global_assignment -name SYSTEMVERILOG_FILE ../rtl/common.sv
 set_global_assignment -name SYSTEMVERILOG_FILE ../rtl/ay.sv
+set_global_assignment -name SYSTEMVERILOG_FILE ../rtl/uart.sv
 set_global_assignment -name SYSTEMVERILOG_FILE ../rtl/top.sv
 set_global_assignment -name VERILOG_INCLUDE_FILE ../rtl/util.vh
 set_global_assignment -name SDC_FILE clocks.sdc


### PR DESCRIPTION
Implement UART with NEXT/MB03-like interface:

port #133B: write - TX data,
            read: bit 0 - RX ready, bit 1 - TX busy

port #143B: read - RX data

UART runs at fixed 115200 baud rate, RX part has 4x oversampling to improve tolerance for baud rate variance.

Currently, it is enabled only on rev.E on following test points:

TP2 - UART_RTS
TP3 - UART_RX
TP4 - UART_TX