### PR TITLE
Timex video modes added - HiRes 512x192 and HiColour 256x192 with attributes field 8x1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Sizif-512
+## Sizif-512 Timex Video
 Another CPLD-based ZX Spectrum clone for 48K rubber case with some sweet features.
 
 [![photo](images/revD.small.jpg)](images/revD.jpg?raw=true)
@@ -15,6 +15,7 @@ Another CPLD-based ZX Spectrum clone for 48K rubber case with some sweet feature
 * PAL and RGB video output (Sega Mini-DIN/9 connector)
 * Digital video output header for EGA monitors, VGA scandoublers, etc.
 * ULAplus
+* Amsoft78 version specyfic: Timex HiColor and HiRes video modes
 * Mono covox (Pentagon ans SpecDrum standards)
 * SounDrive (4-channel stereo covox)
 * WiFi addon ([link](https://github.com/UzixLS/zx-sizif-512-wifi))

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Sizif-512 Timex Video
+## Sizif-512
 Another CPLD-based ZX Spectrum clone for 48K rubber case with some sweet features.
 
 [![photo](images/revD.small.jpg)](images/revD.jpg?raw=true)
@@ -15,13 +15,14 @@ Another CPLD-based ZX Spectrum clone for 48K rubber case with some sweet feature
 * PAL and RGB video output (Sega Mini-DIN/9 connector)
 * Digital video output header for EGA monitors, VGA scandoublers, etc.
 * ULAplus
-* Amsoft78 version specyfic: Timex HiColor and HiRes video modes
+* Timex MultiColor and HiRes support
 * Mono covox (Pentagon ans SpecDrum standards)
 * SounDrive (4-channel stereo covox)
 * WiFi addon ([link](https://github.com/UzixLS/zx-sizif-512-wifi))
 * Tape input via 3.5" jack and Bluetooth
 * 9-12V power supply with any polarity
 * Reset and Magic buttons; header for power button
+
 
 With extension board ([link](https://github.com/UzixLS/zx-sizif-512-ext)) more features may be added:
 * Turbo Sound FM
@@ -86,6 +87,28 @@ Note that DFFDh port available only in Pentagon mode.
 
 ### SD card
 Sizif have preinstalled esxDOS firmware, which provides ability to load TAP, TRD, SCL, Z80 files and save snapshots. To use this you should format SD cart to FAT32 or FAT16 and unpack latest esxDOS release ([link](http://www.esxdos.org/index.html)) to card. Also it's recommended to install Long Filename Browser ([link](https://spectrumcomputing.co.uk/forums/viewtopic.php?t=2553)) to card.
+
+### Timex 2048 MultiColor and HiRes support
+The Timex graphics modes added by amsoft78.
+Basic ways to setup Timex 2048 modes is:
+* OUT 255, 1 - use Timex Screen #1 from 0x6000 instead of 0x4000
+* OUT 255, 2 - sets HiColor mode. Screen bitmap is read from 0x4000, but screen attributes are read from 0x6000. Each 8x1 bitmap has separate attributes entry, in opposite to 8x8 in regular Zx Spectrum.
+* OUT 255, 6 - sets HiRes mode. Screen is now 512x192 in two colors. Both Screen #0 from 0x4000 (odd columns) and 0x6000 (even columns) contains bitmap. Bits 5 to 3 in port 0xFF defines the ink color common for the whole screen. Background colour is always its binary inversion.
+* OUT 255, 0 - sets the regular ZX Spectrum mode.
+
+To activate Timex modes, the followig ports can be used:
+* ZX eLeMeNt compatible port 0x9FFD - shadowing original Timex 0xFF port, but with read and write capabilities.
+* ULA+ compatible method - on port 0xBF3B and "ModeGrop" (bits 7:6 == "01"). See Ula+ specification, as the values are different than for port 0xFF. Warning! As the lot of software first sets the Timex mode by 0xFF, and then sets "01000000" value in 0xBF3B, it would reset Timex mode back to 0. So this combination is ignored - no possibiity to turn off Timex modes via Ula+ port.
+* oryginal Timex 0xFF port - write only. This preserves original ZX Spectrum "Floating Bus", so the port is write-only.
+
+Warning! The method of binary "or" current 0xFF port value, somewhere adviced to use on original Timex 2048, will not work properly:
+
+```
+in      a, (0xFF)
+or      a, 2
+out     (0xFF), a
+```
+
 
 ### Tested addons
 * [AYX-32](https://github.com/tslabs/arm/tree/master/AYX-32) - OK

--- a/cpld/rtl/top.sv
+++ b/cpld/rtl/top.sv
@@ -185,6 +185,7 @@ wire [8:0] vc, hc;
 wire even_line;
 wire clk14, clk7, clk35, ck14, ck7, ck35, clk12_5hz;
 wire vsync0, hsync0;
+wire [5:0] timex_mode;
 assign vsync = zxkit1? clk14 : vsync0;
 assign hsync = zxkit1? csync : hsync0;
 video video0(
@@ -222,7 +223,8 @@ video video0(
     .ck14(ck14),
     .ck7(ck7),
     .ck35(ck35),
-    .clk12_5hz(clk12_5hz)
+    .clk12_5hz(clk12_5hz),
+    .timex_mode(timex_mode)
 );
 
 
@@ -444,6 +446,8 @@ wire [7:0] ports_dout;
 wire ports_dout_active;
 wire beeper, tape_out;
 wire video_page;
+wire uplus_video_page_cs;
+wire uplus_video_page;
 wire rom_page128;
 wire [2:0] ram_pageext;
 wire [2:0] port_1ffd;
@@ -469,7 +473,9 @@ ports ports0 (
     .kempston_data(kempston_data),
     .magic_map(magic_map),
     .tape_in(tape_in),
-
+    .timex_mode(timex_mode),
+    .uplus_video_page_cs(uplus_video_page_cs),
+    .uplus_video_page(uplus_video_page),
     .tape_out(tape_out),
     .beeper(beeper),
     .border(border),
@@ -592,7 +598,11 @@ ulaplus ulaplus0(
     .active(up_active),
     .read_req(up_read_req),
     .write_req(up_write_req),
-    .rw_addr(up_rw_addr)
+    .rw_addr(up_rw_addr),
+    .timex_mode(timex_mode),
+    .uplus_video_page_cs(uplus_video_page_cs),
+    .uplus_video_page(uplus_video_page),
+    .magic_map(magic_map)
 );
 
 

--- a/cpld/rtl/ulaplus.sv
+++ b/cpld/rtl/ulaplus.sv
@@ -11,7 +11,11 @@ module ulaplus(
     output reg active,
     output reg read_req,
     output reg write_req,
-    output [5:0] rw_addr
+    output [5:0] rw_addr,
+    output reg [5:0] timex_mode,
+    output reg uplus_video_page_cs,
+    output reg uplus_video_page,
+    input magic_map
 );
 
 
@@ -22,6 +26,12 @@ wire [7:0] port_ff3b_data = {7'b0000000, active};
 reg [7:0] addr_reg;
 assign rw_addr = addr_reg[5:0];
 
+//shadowing timex mode from timex FF register write, is active even without UP enabled
+// unfortunatelly Sizif Magic menu uses lower-bytes FF port for its own purposes
+wire port_ff_cs = !magic_map && bus.ioreq && bus.a[7:0] == 8'hFF;
+// as well as 9ffd (eLeMeNt ZX)
+wire port_9ffd_cs = bus.ioreq && bus.a[15:0] == 16'h9FFD;
+wire mode_switching_data = (bus.d[7:6] == 2'b01 && bus.d[2:0] != 3'b000);
 always @(posedge clk28 or negedge rst_n) begin
     if (!rst_n) begin
         active <= 0;
@@ -29,10 +39,28 @@ always @(posedge clk28 or negedge rst_n) begin
         read_req <= 0;
         write_req <= 0;
         port_ff3b_rd <= 0;
+        timex_mode <= 0;
+		uplus_video_page_cs <= 0;
+        uplus_video_page <= 0;
     end
     else begin
-        if (port_bf3b_cs && bus.wr)
+        // 01 and all zeros are used to enable ULA+ pallete,
+        // it would also disable timex mode, so exclude it!  
+	     uplus_video_page_cs <= port_bf3b_cs && bus.wr && mode_switching_data;
+        if (port_bf3b_cs && bus.wr) begin
             addr_reg <= bus.d;
+            if (mode_switching_data) begin
+                // some forbidden timex states are used to swith screen 5 to 7 like in spectrum 128
+                timex_mode[0] <= bus.d[0] & ~bus.d[1];
+                // timex FF port bit [1] must be turn on both in hiColor and in hiRes
+                timex_mode[1] <= bus.d[1];
+                timex_mode[2] <= bus.d[1] & bus.d[2];
+                timex_mode[5:3] <= bus.d[5:3];
+                uplus_video_page <= bus.d[2] & ~bus.d[1] & ~bus.d[0];
+            end
+        end
+        if ((port_ff_cs || port_9ffd_cs) && bus.wr)
+            timex_mode <= bus.d[5:0];
         if (port_ff3b_cs && bus.wr && addr_reg == 8'b01000000)
             active <= bus.d[0];
 

--- a/cpld/rtl/video.sv
+++ b/cpld/rtl/video.sv
@@ -189,7 +189,6 @@ wire timex_hi_res = timex_mode[2]; // must be set together with [1]
 
 wire screen_show = (vc < V_AREA) && (hc0 >= (SCREEN_DELAY<<2) - 1) && (hc0 < ((H_AREA + SCREEN_DELAY)<<2) - 1);
 wire screen_update = hc0[4:0] == 5'b10011;
-wire odd_column_update = (hc0[4:0] == 5'b00011) && timex_hi_res;
 wire border_update = (hc0[4:0] == 5'b10011) || (machine == MACHINE_PENT && ck7);
 wire bitmap_shift = hc0[1:0] == 2'b11 || timex_hi_res && hc0[0] == 1'b1;
 wire next_addr = hc0[4:0] == 5'b10001;
@@ -211,7 +210,7 @@ always @(posedge clk28 or negedge rst_n) begin
     end
 end
 
-reg [7:0] bitmap, attr, bitmap_next, attr_next, bitmap_odd;
+reg [7:0] bitmap, attr, bitmap_next, attr_next, bitmap_odd, bitmap_odd_next;
 reg [7:0] up_ink, up_paper, up_ink_next, up_paper_next;
 
 reg [1:0] read_step, read_step_cur;
@@ -234,6 +233,7 @@ always @(posedge clk28 or negedge rst_n) begin
         bitmap_next <= 0;
         up_ink_next <= 0;
         up_paper_next <= 0;
+        bitmap_odd_next <= 0;		  
     end
     else begin
         if (next_addr)
@@ -246,8 +246,14 @@ always @(posedge clk28 or negedge rst_n) begin
         if (read_req_ack)
             read_step_cur <= read_step;
 
-        if (read_data_valid && read_step_cur == 2'd0 && screen_read)
-            attr_next <= read_data;
+        if (read_data_valid && read_step_cur == 2'd0 && screen_read) begin
+            if (timex_hi_res) begin
+                bitmap_odd_next <= read_data;
+                attr_next <= {2'b00, ~timex_mode[5:3], timex_mode[5:3]};
+            end
+            else
+                attr_next <= read_data;
+        end
         else if (!screen_read && hc0[0])
             attr_next <= {2'b00, border[2:0], border[2:0]};
 
@@ -267,28 +273,25 @@ always @(posedge clk28 or negedge rst_n) begin
     if (!rst_n) begin
         attr <= 0;
         bitmap <= 0;
+        bitmap_odd <= 0;
         up_ink <= 0;
         up_paper <= 0;
     end
     else begin
         if (screen_show && screen_update) begin
-            if (timex_hi_res)
-                attr <= {2'b00, ~timex_mode[5:3], timex_mode[5:3]};
-            else
-                attr <= attr_next;
-            end
+            attr <= attr_next;
+        end
         else if (!screen_show && border_update)
             attr <= {2'b00, border[2:0], border[2:0]};
 
         if (screen_update) begin
             bitmap <= bitmap_next;
-            bitmap_odd <= attr_next;
+            bitmap_odd <= bitmap_odd_next;
         end
-        else if (odd_column_update)
-            bitmap <= bitmap_odd;
-        else if (bitmap_shift)
-            bitmap <= {bitmap[6:0], 1'b0};
-
+        else if (bitmap_shift) begin
+            bitmap <= {bitmap[6:0], bitmap_odd[7]};
+            bitmap_odd <= {bitmap_odd[6:0], 1'b0};
+        end
         if (screen_update)
             up_ink <= up_ink_next;
         if (screen_update)
@@ -298,13 +301,10 @@ end
 
 
 /* ATTRIBUTE PORT */
-// if timex mode turned on, returns it, for ability to detect timex mode!
 wire port_ff_attr = (machine == MACHINE_PENT) || hc[3:1] == 3'h6 || hc[3:1] == 3'h0;
 wire port_ff_bitmap = (hc[3] && hc[1]);
-wire timex_mode_active = (timex_mode[5:0] != 6'b000000);
-assign port_ff_active = timex_mode_active || screen_read && (port_ff_attr || port_ff_bitmap);
+assign port_ff_active = screen_read && (port_ff_attr || port_ff_bitmap);
 assign port_ff_data =
-    timex_mode_active? {2'b00, timex_mode[5:0]} :
     port_ff_attr? attr_next :
     port_ff_bitmap? bitmap_next :
     8'hFF;


### PR DESCRIPTION
This is my proposal how to implement Timex 2048 Hires and HiColor modes.
It has been tested with some Timex-only Demos and Time Game "Hi-Color Hero".
(https://peteshobby.itch.io/hi-color-hero).

Note, that I left 0xFF read to be "spectrum bus-float" compatible. But it causes some software which first reads the 0xFF port value to work improper. For example the "Hi-Color Hero" Timex 2048 will not show proper Hi-Color Version. One must use the ZX eLeMeNt version.